### PR TITLE
fixed bug for series with < 10 elements

### DIFF
--- a/R/MK_tempAggr.R
+++ b/R/MK_tempAggr.R
@@ -78,7 +78,7 @@ MK.tempAggr <- function(data, PW.method = "3PW", resolution, alpha.mk = 95, alph
         }
 
         if (PW.method == '3PW')  {
-
+            print("datapw ", str(dataPW))
             result.PW <- compute.MK.stat(data = dataPW$PW, t.time = t.time, resolution = resolution, alpha.mk = alpha.mk, alpha.cl = alpha.cl)$result
 
             result.TFPW.Y <- compute.MK.stat(data = dataPW$TFPW.Y, t.time = t.time, resolution = resolution, alpha.mk = alpha.mk, alpha.cl = alpha.cl)$result

--- a/R/compute_MK_stat.R
+++ b/R/compute_MK_stat.R
@@ -18,19 +18,25 @@
 
 compute.MK.stat <- function(data, t.time, resolution, alpha.mk = 95, alpha.cl = 90) {
 
+    message(str(data), " 1")
+ 
     t <- Nb.tie(data = data, resolution = resolution)
     out <- S.test(data = data, t.time = t.time)
     S <- out$S
     n <- out$n
     result <- list()
+
+    message(str(data), " 2")
     
     vari <- Kendall.var(data = data, t = t, n = n)
     Z <- STD.normale.var(data = S, var.data = vari)
+    message(str(data), " 3")
     if ( sum(data, na.rm = TRUE) > 10 ) {
         result$P <- 2 * (1 - pnorm( abs(Z), 0, 1))
     } else {
-        Prob.MK.n <- read.table('prob_mk_n.csv', sep=",", header = FALSE)
+        ## Prob.MK.n <- read.table('prob_mk_n.csv', sep=",", header = FALSE)
         result$P <- Prob.MK.n[ abs(S) + 1, sum(data, na.rm = TRUE)]
+        message(str(data), " 4")
     }
     
     ## determine the ss

--- a/R/prewhite.R
+++ b/R/prewhite.R
@@ -187,7 +187,7 @@ prewhite <- function(data.ts, column, resolution, alpha.ak = 95){
         ## no s.s. autocorrelation
         dataPW$PW <-  data
         dataPW$PW.cor <-  data
-        dataPW$TFP.Y <-  data
+        dataPW$TFPW.Y <-  data
         dataPW$TFPW.WS <-  data
         dataPW$VCTFPW <-  data
     }


### PR DESCRIPTION
**Description:**

compute_mk_stat.R was not using the internal (package) data for the probability table in case of short time series.
This bug was also hiding a typo in prewhite.R


**Checklists**:
- [ ] New code includes dedicated tests.
- [ ] New code follows the project's style.
- [ ] New code is compatible with BSD 3-Clause license.
