### PR TITLE
Update CI_docs_build_and_publish.yml

### DIFF
--- a/.github/workflows/CI_docs_build_and_publish.yml
+++ b/.github/workflows/CI_docs_build_and_publish.yml
@@ -5,15 +5,17 @@
 # the ./docs/build/ folder are published as-is in a gh-pages branch of the repo, with only
 # .nojekyll, .gitignore, and .git (folder) in addition.
 #
-# This Action will be triggered only if the docs are actually changed in the push.
+# This Action will be triggered for any push to the master branch.
 
 name: CI_docs_publish
 
 on:
   push:
     branches: [ master ]
-    paths:
-      - 'docs/**'
+    # Run the action only if certain files are changed.
+    #paths:
+    #  - 'docs/**'
+    #  - 'VERSION'
   # For dev purposes, doing it on PR helps a lot
   #pull_request:
   #  branches: [ master ]


### PR DESCRIPTION
**Description:**

Hi @abigmo. This PR changes the automatic Github actions, such that from now on **any** push to master will trigger the publication of the docs. 

I'll let you merge it as you see fit.

**Checklists**:
- [ ] New code includes dedicated tests.
- [x] New code follows the project's style.
- [x] New code is compatible with BSD 3-Clause license.
- [ ] AUTHORS has been updated.
